### PR TITLE
test PSPDFKit version 8.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "Minitex/MinitexPDFProtocols" ~> 0.0.5
-binary "PSPDFKit.json" ~> 7.6.2
+binary "PSPDFKit.json" ~> 8.2


### PR DESCRIPTION
This PR will bump the version of PSPDFKit.json we're using to 8.2. Currently, there is a pre-release tag attached to this branch as well: 

https://github.com/Minitex/PDF-iOS/releases/tag/v1.0.5-alpha